### PR TITLE
Don't require an exact version of lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "vinyl-source-stream": "^1.1.0"
   },
   "dependencies": {
-    "lodash": "3.5.0"
+    "lodash": "^3.5.0"
   }
 }


### PR DESCRIPTION
This causes any module using foldspander to install a duplicate lodash when it requires an up to date copy of lodash.
